### PR TITLE
fix: replace `web3community` with `WebXDAO`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -25,7 +25,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/web3community/.github/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,7 +1,7 @@
 blank_issues_enabled: false
 contact_links:
   - name: Our socials
-    url: https://bio.link/web3community
+    url: https://bio.link/WebXDAO
     about: Feel free to contact us via your preferred platform.
   - name: Discord community
     url: https://discord.gg/TSRwqx4K2v

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -40,7 +40,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/web3community/.github/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/ISSUE_TEMPLATE/other.yml
+++ b/.github/ISSUE_TEMPLATE/other.yml
@@ -31,7 +31,7 @@ body:
     id: terms
     attributes:
       label: Code of Conduct
-      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/web3community/.github/blob/main/CODE_OF_CONDUCT.md)
+      description: By submitting this issue, you agree to follow our [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
       options:
         - label: I agree to follow this project's Code of Conduct
           required: true

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -47,4 +47,4 @@ Example how to mark a checkbox:-
 
 ## Code of Conduct
 
-- [ ] I agree to follow this project's [Code of Conduct](https://github.com/web3community/.github/blob/main/CODE_OF_CONDUCT.md)
+- [ ] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,7 +6,7 @@ The following is a set of guidelines for contributing to this project. These are
 
 ## Code of Conduct 📜
 
-This project and everyone participating in it is governed by a [Code of Conduct](https://github.com/web3community/web3community.github.io/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to one of our moderators via your preferred platform or in our [Discord server](https://discord.gg/TSRwqx4K2v).
+This project and everyone participating in it is governed by a [Code of Conduct](https://github.com/WebXDAO/WebXDAO.github.io/blob/main/CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code. Please report unacceptable behavior to one of our moderators via your preferred platform or in our [Discord server](https://discord.gg/TSRwqx4K2v).
 
 ## How can I contribute? 🤔
 
@@ -20,7 +20,7 @@ This section guides you through submitting a bug report. Following these guideli
 
 This section guides you through submitting an enhancement suggestion, including completely new features and minor improvements to existing functionality. Following these guidelines helps maintainers and the community understand your suggestion 📝 and find related suggestions 🔎.
 
-Since the new GitHub Issue forms we only suggest you to include most information possible. But you can also **Perform a [cursory search](https://github.com/web3community/web3community.github.io/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
+Since the new GitHub Issue forms we only suggest you to include most information possible. But you can also **Perform a [cursory search](https://github.com/WebXDAO/WebXDAO.github.io/issues)** to see if the enhancement has already been suggested. If it has, add a comment to the existing issue instead of opening a new one.
 
 > **Note:** If you find a **Closed** issue that seems like it is the same thing that you're experiencing, open a new issue and include a link to the original issue in the body of your new one.
 
@@ -28,8 +28,8 @@ Since the new GitHub Issue forms we only suggest you to include most information
 
 Unsure where to begin contributing to this project? You can start by looking through these `beginner` and `help-wanted` issues:
 
-- [Beginner-friendly issues](https://github.com/web3community/web3community.github.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
-- [Help wanted issues](https://github.com/web3community/web3community.github.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) - issues which should be a bit more involved than `beginner` issues.
+- [Beginner-friendly issues](https://github.com/WebXDAO/WebXDAO.github.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22good+first+issue%22) - issues which should only require a few lines of code, and a test or two.
+- [Help wanted issues](https://github.com/WebXDAO/WebXDAO.github.io/issues?q=is%3Aopen+is%3Aissue+label%3A%22help+wanted%22) - issues which should be a bit more involved than `beginner` issues.
 
 ### Pull Requests 📣
 
@@ -40,7 +40,7 @@ The process described here has several goals:
 - Engage the community in working toward the best possible!
 - Enable a sustainable system for maintainers to review contributions
 
-Please follow all instructions in [the template](https://github.com/web3community/web3community.github.io/blob/main/.github/pull_request_template.md)
+Please follow all instructions in [the template](https://github.com/WebXDAO/WebXDAO.github.io/blob/main/.github/pull_request_template.md)
 
 ## Style Guide for Git Commit Messages :memo:
 
@@ -54,12 +54,12 @@ Please follow all instructions in [the template](https://github.com/web3communit
 - Do not end the subject line with a period.
 - Wrap the body at *72 characters*.
 - Use the body to explain the *what*, *why*, *vs*, and *how*.
-- Reference [Issues](https://github.com/web3community/web3community.github.io/issues) and [Pull Requests](https://github.com/web3community/web3community.github.io/pulls) liberally after the first line.
+- Reference [Issues](https://github.com/WebXDAO/WebXDAO.github.io/issues) and [Pull Requests](https://github.com/WebXDAO/WebXDAO.github.io/pulls) liberally after the first line.
 - Follow [conventional commits](https://www.conventionalcommits.org/en/v1.0.0/)
 
 ## 🚀 How to Contribute
 
-- Please create an [issue](https://github.com/web3community/web3community.github.io/issues/new/choose) before creating a pull request.
+- Please create an [issue](https://github.com/WebXDAO/WebXDAO.github.io/issues/new/choose) before creating a pull request.
 
 - Fork the repository and create a branch for any issue that you are working on.
 
@@ -69,18 +69,18 @@ Please follow all instructions in [the template](https://github.com/web3communit
 
 ## 🤔 How to make a pull request
 
-**1.** Fork [this](https://github.com/web3community/web3community.github.io) repository. Click on the <a  href="https://github.com/web3community/web3community.github.io"><img  src="https://img.icons8.com/fluency/30/000000/code-fork.png"/></a> symbol at the top right corner.
+**1.** Fork [this](https://github.com/WebXDAO/WebXDAO.github.io) repository. Click on the <a  href="https://github.com/WebXDAO/WebXDAO.github.io"><img  src="https://img.icons8.com/fluency/30/000000/code-fork.png"/></a> symbol at the top right corner.
 
 **2.** Clone the forked repository.
 
 ```bash
-git clone https://github.com/<your-username>/web3community.github.io.git
+git clone https://github.com/<your-username>/WebXDAO.github.io.git
 ```
 
 **3.** Navigate to the project directory.
 
 ```bash
-cd web3community.github.io
+cd WebXDAO.github.io
 ```
 
 **4.** Create a new branch:
@@ -122,7 +122,7 @@ git push origin your-branch-name
 
 After this, the project maintainers will review the changes and will merge your PR if they found it good, otherwise we will suggest the required changes.
 
-## Web3Community 🌐
+## WebXDAO 🌐
 
 - 😕 Not sure where to start? Join our community on [Discord](https://discord.gg/TSRwqx4K2v)
-- ✨ You can also take part in [Community Discussion](https://github.com/web3community/web3community.github.io/discussions)
+- ✨ You can also take part in [Community Discussion](https://github.com/WebXDAO/WebXDAO.github.io/discussions)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ The content in this repository is temporary, we are making new web design for We
 
 ### 1\. Skip all of the steps below by using Gitpod, which would automatically do all of that for you
 
-[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/web3community/web3community.github.io)
+[![Open in Gitpod](https://gitpod.io/button/open-in-gitpod.svg)](https://gitpod.io/#https://github.com/WebXDAO/WebXDAO.github.io)
 
 ### 2\. Clone this Repository
 

--- a/components/Global/Blogs.jsx
+++ b/components/Global/Blogs.jsx
@@ -52,7 +52,7 @@ const Blogs = ({ articles, contentOnly = false, show = articles.length }) => {
       </div>
       {!contentOnly && (
         <div className='flex justify-center'>
-          <a href='https://dev.to/web3community' target='_blank' rel='noreferrer'>
+          <a href='https://dev.to/WebXDAO' target='_blank' rel='noreferrer'>
             <button className='bg-gray-700 text-white mx-auto lg:mx-0 rounded-md py-2 px-8 shadow transform transition hover:scale-85 hover:shadow-lg duration-300 ease-in-out'>
               See All
             </button>

--- a/components/Global/Footer.jsx
+++ b/components/Global/Footer.jsx
@@ -3,7 +3,7 @@ const Footer = () => {
   const settings = {
     name: 'WebXDAO',
     author: 'WebXDAO',
-    url: 'https://web3community.github.io'
+    url: 'https://WebXDAO.github.io'
   }
   const socials = [
     {
@@ -14,20 +14,20 @@ const Footer = () => {
     },
     {
       name: 'Instagram',
-      url: 'https://www.instagram.com/web3community/',
+      url: 'https://www.instagram.com/WebXDAO/',
       icon: FaInstagram,
       text: 'Check our content at Instagram'
     },
     {
       name: 'Twitter',
-      url: 'https://twitter.com/web3community',
+      url: 'https://twitter.com/WebXDAO',
       icon: FaTwitter,
       text: 'Follow us via Twitter'
     },
 
     {
       name: 'Linkedin',
-      url: 'https://www.linkedin.com/company/web3community',
+      url: 'https://www.linkedin.com/company/WebXDAO',
       icon: FaLinkedin,
       text: 'Connect with us at LinkedIn'
     },

--- a/components/Home/DeveloperPath.jsx
+++ b/components/Home/DeveloperPath.jsx
@@ -81,7 +81,7 @@ const DeveloperPath = () => {
 
         <div className='flex justify-center items-center py-5'>
           <a
-            href='https://github.com/web3community/blockchain-dev-path'
+            href='https://github.com/WebXDAO/blockchain-dev-path'
             target='_blank'
             rel='noreferrer'
           >

--- a/pages/moderators.js
+++ b/pages/moderators.js
@@ -101,7 +101,7 @@ export function getStaticProps() {
     },
     {
       name: 'Max Kubik',
-      bio: 'Web2 Fullstack Software Engineer 💠 I build webapps and mobile apps for the industry field 🔧 Transitioning to Web3 stacks 🌠 Maintainer for @Web3community 🍬 Open-source newbie!',
+      bio: 'Web2 Fullstack Software Engineer 💠 I build webapps and mobile apps for the industry field 🔧 Transitioning to Web3 stacks 🌠 Maintainer for @WebXDAO 🍬 Open-source newbie!',
       imgUrl: 'https://github.com/mkubdev.png',
       twitterUrl: 'https://twitter.com/digikube1',
       githubUrl: 'https://github.com/mkubdev'


### PR DESCRIPTION
### Describe the changes you've made

- Replace `web3community` with `WebXDAO`.
  - There are still other repositories that still use `web3community`. Might want to update those as well.

<!-- Give a clear description of what modifications you have made -->

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?

I don't think this applies here.

<!-- Describe how have you verified the changes made -->

## Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [ ] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)


<a href="https://gitpod.io/#https://github.com/WebXDAO/WebXDAO.github.io/pull/181"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

