### PR TITLE
fix: accessibility issues on homepage

### DIFF
--- a/src/components/Global/Footer.js
+++ b/src/components/Global/Footer.js
@@ -69,7 +69,7 @@ const Footer = () => {
                     {item.name}
                   </p>
 
-                  <nav className="mt-8">
+                  <nav className="mt-8" aria-label={item.name}>
                     <ul className="space-y-4 text-sm">
                       {item.children.map((child) => (
                         <li key={child.name}>

--- a/src/components/Global/Footer.js
+++ b/src/components/Global/Footer.js
@@ -45,7 +45,11 @@ const Footer = () => {
             <div className="flex justify-center text-teal-600 sm:justify-start">
               <a href="#">
                 <span className="sr-only">WebX DAO</span>
-                <img className="w-auto h-8 sm:h-10" src="/images/logo/white_logo.png" alt="" />
+                <img
+                  className="w-auto h-8 sm:h-10"
+                  src="/images/logo/white_logo.png"
+                  alt=""
+                />
               </a>
             </div>
             {/* 
@@ -55,16 +59,24 @@ const Footer = () => {
           </div>
 
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:col-span-2 md:grid-cols-4">
-            {navigation.map(item => (
+            {navigation.map((item) => (
               <>
-                <div key={item.name + '_footer'} className="text-center sm:text-left">
-                  <p className="text-sm font-medium text-white/90">{item.name}</p>
+                <div
+                  key={item.name + "_footer"}
+                  className="text-center sm:text-left"
+                >
+                  <p className="text-sm font-medium text-white/90">
+                    {item.name}
+                  </p>
 
-                  <nav className="mt-8" aria-label={item.name}>
+                  <nav className="mt-8">
                     <ul className="space-y-4 text-sm">
-                      {item.children.map(child => (
+                      {item.children.map((child) => (
                         <li key={child.name}>
-                          <Link className="transition text-white/60 hover:text-white/60/75" href="/">
+                          <Link
+                            className="transition text-white/60 hover:text-white/60/75"
+                            href="/"
+                          >
                             <span className="text-white/60">{child.name}</span>
                           </Link>
                         </li>
@@ -86,7 +98,10 @@ const Footer = () => {
             <p className="mt-4 text-sm text-gray-500 sm:order-first sm:mt-0">
               <span className="flex items-center justify-center">
                 &copy; {new Date().getFullYear()} Made with
-                <SiGithubsponsors className="w-3 h-3 m-2 text-pink-600" aria-hidden="true" />
+                <SiGithubsponsors
+                  className="w-3 h-3 m-2 text-pink-600"
+                  aria-hidden="true"
+                />
                 by WebX DAO
               </span>
             </p>
@@ -94,7 +109,7 @@ const Footer = () => {
         </div>
       </div>
     </footer>
-  )
+  );
 };
 
 export default Footer;

--- a/src/components/Global/Footer.js
+++ b/src/components/Global/Footer.js
@@ -45,11 +45,7 @@ const Footer = () => {
             <div className="flex justify-center text-teal-600 sm:justify-start">
               <a href="#">
                 <span className="sr-only">WebX DAO</span>
-                <img
-                  className="w-auto h-8 sm:h-10"
-                  src="/images/logo/white_logo.png"
-                  alt=""
-                />
+                <img className="w-auto h-8 sm:h-10" src="/images/logo/white_logo.png" alt="" />
               </a>
             </div>
             {/* 
@@ -59,24 +55,16 @@ const Footer = () => {
           </div>
 
           <div className="grid grid-cols-1 gap-8 sm:grid-cols-2 lg:col-span-2 md:grid-cols-4">
-            {navigation.map((item) => (
+            {navigation.map(item => (
               <>
-                <div
-                  key={item.name + "_footer"}
-                  className="text-center sm:text-left"
-                >
-                  <p className="text-sm font-medium text-white/90">
-                    {item.name}
-                  </p>
+                <div key={item.name + '_footer'} className="text-center sm:text-left">
+                  <p className="text-sm font-medium text-white/90">{item.name}</p>
 
-                  <nav className="mt-8">
+                  <nav className="mt-8" aria-label={item.name}>
                     <ul className="space-y-4 text-sm">
-                      {item.children.map((child) => (
+                      {item.children.map(child => (
                         <li key={child.name}>
-                          <Link
-                            className="transition text-white/60 hover:text-white/60/75"
-                            href="/"
-                          >
+                          <Link className="transition text-white/60 hover:text-white/60/75" href="/">
                             <span className="text-white/60">{child.name}</span>
                           </Link>
                         </li>
@@ -98,10 +86,7 @@ const Footer = () => {
             <p className="mt-4 text-sm text-gray-500 sm:order-first sm:mt-0">
               <span className="flex items-center justify-center">
                 &copy; {new Date().getFullYear()} Made with
-                <SiGithubsponsors
-                  className="w-3 h-3 m-2 text-pink-600"
-                  aria-hidden="true"
-                />
+                <SiGithubsponsors className="w-3 h-3 m-2 text-pink-600" aria-hidden="true" />
                 by WebX DAO
               </span>
             </p>
@@ -109,7 +94,7 @@ const Footer = () => {
         </div>
       </div>
     </footer>
-  );
+  )
 };
 
 export default Footer;

--- a/src/components/Home/HeroSection/ContributeButton.js
+++ b/src/components/Home/HeroSection/ContributeButton.js
@@ -4,19 +4,16 @@ import Link from 'next/link';
 const ContributeButton = () => {
   return (
     <>
-      <motion.button
+      <motion.a
         className="inline-flex items-center justify-center px-8 py-3 text-base font-medium transition-all duration-100 bg-gray-100 border border-transparent rounded-md shadow-md border-dark hover:border-white/80 text-slate-700 hover:bg-gray-700 hover:text-slate-100 focus:outline-none focus:ring-2 focus:ring-cyber-webx focus:ring-offset-2"
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 1 }}
+        href="https://github.com/webxdao"
       >
-        <Link href="https://github.com/webxdao">
-          <a className="inline-flex items-center justify-center w-full">
-            Contribute
-          </a>
-        </Link>
-      </motion.button>
+        Contribute
+      </motion.a>
     </>
-  );
+  )
 };
 
 export default ContributeButton;

--- a/src/components/Home/HeroSection/ContributeButton.js
+++ b/src/components/Home/HeroSection/ContributeButton.js
@@ -13,7 +13,7 @@ const ContributeButton = () => {
         Contribute
       </motion.a>
     </>
-  )
+  );
 };
 
 export default ContributeButton;

--- a/src/components/Home/HeroSection/DiscordButton.js
+++ b/src/components/Home/HeroSection/DiscordButton.js
@@ -15,7 +15,7 @@ const DiscordButton = () => {
         <FaDiscord className="w-5 h-5 ml-3 -mr-1" aria-hidden="true" />
       </motion.a>
     </>
-  )
+  );
 };
 
 export default DiscordButton;

--- a/src/components/Home/HeroSection/DiscordButton.js
+++ b/src/components/Home/HeroSection/DiscordButton.js
@@ -5,20 +5,17 @@ import Link from 'next/link';
 const DiscordButton = () => {
   return (
     <>
-      <motion.button
+      <motion.a
         className="inline-flex items-center justify-center px-4 py-3 text-base font-medium transition-all duration-100 border border-transparent rounded-md shadow-sm hover:border-white/80 bg-cyber-webx text-white/80 hover:text-white hover:bg-gradient-to-r hover:from-pink-700 hover:to-pink-900 focus:outline-none focus:ring-2 focus:ring-cyber-webx focus:ring-offset-2"
         whileHover={{ scale: 1.05 }}
         whileTap={{ scale: 1 }}
+        href="https://dsc.gg/webxdao"
       >
-        <Link href="https://dsc.gg/webxdao">
-          <a className="inline-flex items-center justify-center w-full">
-            Join WebXDAO
-            <FaDiscord className="w-5 h-5 ml-3 -mr-1" aria-hidden="true" />
-          </a>
-        </Link>
-      </motion.button>
+        Join WebXDAO
+        <FaDiscord className="w-5 h-5 ml-3 -mr-1" aria-hidden="true" />
+      </motion.a>
     </>
-  );
+  )
 };
 
 export default DiscordButton;

--- a/src/pages/_document.js
+++ b/src/pages/_document.js
@@ -1,0 +1,13 @@
+import { Html, Head, Main, NextScript } from 'next/document'
+
+export default function Document() {
+  return (
+    <Html lang="en">
+      <Head />
+      <body>
+        <Main />
+        <NextScript />
+      </body>
+    </Html>
+  )
+}


### PR DESCRIPTION
## Related Issue

- Information about the related issue

Closes: #211 

### Describe the changes you've made

Added a _document.js page so that a language attribute could be added to the html tag
Added aria labels to each navigation in footer
Updated the two call to action buttons so they didn't contain nested links but are instead links styled as buttons

## Type of change

What sort of change have you made:
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?

Visually, with Axe Dev tools and manual keyboard tests

## Checklist
<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->
- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [ ] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)

 Original           | Updated
 :--------------------: |:--------------------:
 original screenshot | updated screenshot |

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)


<a href="https://gitpod.io/#https://github.com/WebXDAO/WebXDAO.github.io/pull/212"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

