### PR TITLE
docs: minor grammatical error fix

### DIFF
--- a/src/components/Home/HeroSection/Hero.js
+++ b/src/components/Home/HeroSection/Hero.js
@@ -1,7 +1,7 @@
-import CallToActionHero from "./CallToActionHero";
-import DiscordButton from "./DiscordButton";
-import ContributeButton from "./ContributeButton";
-import Link from "next/link";
+import CallToActionHero from './CallToActionHero';
+import DiscordButton from './DiscordButton';
+import ContributeButton from './ContributeButton';
+import Link from 'next/link';
 
 export default function Hero() {
   return (
@@ -35,7 +35,7 @@ export default function Hero() {
                         <p className="mt-3 text-sm text-white/70 sm:mt-4">
                           We are an opensource community working around the
                           future of the web. Learn blockchain technology
-                          together. The community is powered by{" "}
+                          together. The community is powered by{' '}
                           <Link href="https://devprotocol.xyz/">
                             <a className="font-medium text-white">
                               Dev Protocol

--- a/src/components/Home/HeroSection/Hero.js
+++ b/src/components/Home/HeroSection/Hero.js
@@ -1,7 +1,7 @@
-import CallToActionHero from './CallToActionHero';
-import DiscordButton from './DiscordButton';
-import ContributeButton from './ContributeButton';
-import Link from 'next/link';
+import CallToActionHero from "./CallToActionHero";
+import DiscordButton from "./DiscordButton";
+import ContributeButton from "./ContributeButton";
+import Link from "next/link";
 
 export default function Hero() {
   return (
@@ -33,9 +33,9 @@ export default function Hero() {
                         </div>
                         <CallToActionHero></CallToActionHero>
                         <p className="mt-3 text-sm text-white/70 sm:mt-4">
-                          We are a opensource community working around the
+                          We are an opensource community working around the
                           future of the web. Learn blockchain technology
-                          together. The community is powered by{' '}
+                          together. The community is powered by{" "}
                           <Link href="https://devprotocol.xyz/">
                             <a className="font-medium text-white">
                               Dev Protocol


### PR DESCRIPTION
## Related Issue

- There was a grammatical mistake in the hero part of the website:
```
We are a opensource community...
```

Changed to:
```
We are an opensource community
```

### Describe the changes you've made
`a` changed to `an` to make it grammatically correct


## Type of change

What sort of change have you made:

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?
No tests need because of it being an extremely minor change

## Checklist
- [ x] My code follows the guidelines of this project.
- [ x] I have performed a self-review of my own code.
- [ x] I have commented on my code, particularly wherever it was hard to understand.
- [ x] I have made corresponding changes to the documentation.
- [ x] My changes generate no new warnings.
- [ x] I have added tests that prove my fix is effective or that my feature works.
- [ x] Any dependent changes have been merged and published in downstream modules.

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)


<a href="https://gitpod.io/#https://github.com/WebXDAO/WebXDAO.github.io/pull/213"><img src="https://gitpod.io/button/open-in-gitpod.svg"/></a>

