### PR TITLE
Fix : issue #311

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -86,15 +86,25 @@ export default function IndexPage() {
             Become an integral part of a dynamic and vibrant network of like-minded developers
           </h3>
           <div className="mt-4 flex gap-4">
+          <Link  target="_blank"
+              rel="noreferrer"
+              href={siteConfig.links.webxdao_twitter} >
             <div className="flex items-center">
+              
               <Icons.twitter className="mr-1 h-5 w-5 cursor-pointer fill-current" />
               <span className="cursor-pointer">Twitter</span>
-            </div>
-
+              
+              </div>
+              </Link>
+              
+              <Link  target="_blank"
+              rel="noreferrer"
+              href={siteConfig.links.webxdao_discord} >
             <div className="flex items-center">
               <Icons.discord className="mr-1 h-5 w-5 cursor-pointer fill-current" />
               <span className="cursor-pointer">Discord</span>
             </div>
+            </Link>
           </div>
         </div>
       </section>

--- a/config/site.ts
+++ b/config/site.ts
@@ -31,6 +31,8 @@ export const siteConfig = {
     github: "https://github.com/shadcn/ui",
     docs: "https://ui.shadcn.com",
     webxdao_gh: "https://github.com/WebXDAO/",
-    webxdao_getstarted: "https://github.com/WebXDAO/start-here"
+    webxdao_getstarted: "https://github.com/WebXDAO/start-here",
+    webxdao_discord:"https://discord.webxdao.xyz/",
+    webxdao_twitter:"https://twitter.com/WebXDAO"
   },
 }


### PR DESCRIPTION
## Related Issue

Issue #311 is about When we click on Twitter and Discord logo it does not redirect us to WebXDAO Twitter and Discord pages.

Closes: #311 

### Describe the changes you've made

I have added official links of WebXDAO to Twitter and Discord logo . Now when we will click on them it will redirect us to WebXDAO official pages.

## Type of change

What sort of change have you made:



- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?

After making changes I ran website on my local environment and check each link . 

## Checklist

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| original screenshot | updated screenshot |

## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
