### PR TITLE
Fix : issue #312

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -7,9 +7,11 @@ import { siteConfig } from "@/config/site";
 import Image from "next/image";
 import Link from "next/link";
 
+
 export default function IndexPage() {
   return (
     <>
+    
       {/* TODO: How can i put the image in the background.. absolute / relative thingy */}
 
       <section className="relative flex min-h-screen flex-col items-center justify-center overflow-hidden text-center">
@@ -165,13 +167,13 @@ export default function IndexPage() {
               </p>
             </div>
             <div className="flex justify-end px-6 pb-2 pt-4">
-              <span className="w-fit-content font-inter text-14.0418 mb-0 mr-auto flex cursor-pointer gap-6 rounded border-2 border-solid border-black px-4 py-1 font-semibold text-black">
+              <span className="w-fit-content font-inter text-14.0418 mb-0 mr-auto flex cursor-pointer gap-6 rounded border-2 border-solid border-black px-4 py-1 font-semibold text-black transition duration-400 ease-in hover:bg-indigo-800 hover:text-white hover:border-indigo-800">
                 <Image
                   src="/Arrow1.png"
                   alt="arrow"
                   width={15}
                   height={18}
-                  className="my-auto flex items-center"
+                  className="my-auto flex items-center hover:invert" 
                 />
                 Read More
               </span>
@@ -187,13 +189,13 @@ export default function IndexPage() {
               </p>
             </div>
             <div className="mt-10 flex justify-end px-6 pb-2 pt-4">
-              <span className="w-fit-content font-inter text-14.0418 mb-0 mr-auto flex cursor-pointer gap-6 rounded border-2 border-solid border-black px-4 py-1 font-semibold text-black">
+              <span className="w-fit-content font-inter text-14.0418 mb-0 mr-auto flex cursor-pointer gap-6 rounded border-2 border-solid border-black px-4 py-1 font-semibold text-black transition duration-400 ease-in hover:bg-indigo-800 hover:text-white hover:border-indigo-800">
                 <Image
                   src="/Arrow1.png"
                   alt="arrow"
                   width={15}
                   height={18}
-                  className="my-auto flex items-center"
+                  className="my-auto flex items-center hover:invert"
                 />
                 Read More
               </span>
@@ -209,13 +211,13 @@ export default function IndexPage() {
               </p>
             </div>
             <div className="mt-12 flex justify-end px-6 pb-2 pt-4">
-              <span className="w-fit-content font-inter text-14.0418 mb-0 mr-auto flex cursor-pointer gap-6 rounded border-2 border-solid border-black px-4 py-1 font-semibold text-black">
+              <span className="w-fit-content font-inter text-14.0418 mb-0 mr-auto flex cursor-pointer gap-6 rounded border-2 border-solid border-black px-4 py-1 font-semibold text-black transition duration-400 ease-in hover:bg-indigo-800 hover:text-white hover:border-indigo-800">
                 <Image
                   src="/Arrow1.png"
                   alt="arrow"
                   width={15}
                   height={18}
-                  className="my-auto flex items-center"
+                  className="my-auto flex items-center hover:invert"
                 />
                 Read More
               </span>


### PR DESCRIPTION
## Related Issue

Hovering Effect on Community Partners Section Cards "Read More" buttons.

Closes: #312 

### Describe the changes you've made

I have added hovering effect on the Community Partners Section Cards "Read More" buttons as told by maintainers.

## Type of change

What sort of change have you made:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?
I have setup website on my local environment and then run it  and tested the changes.

## Checklist

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [ ] I have commented on my code, particularly wherever it was hard to understand.
- [ ] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| ![webxdaobefore](https://github.com/WebXDAO/WebXDAO.github.io/assets/85991449/ee398628-80ae-4874-b528-14c6e3d7df18) | ![webxdaoafter](https://github.com/WebXDAO/WebXDAO.github.io/assets/85991449/0ded8d39-e5f3-47d1-b5b1-67ebec962c28) |




## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
