### PR TITLE
💡 [FEAT]: ACCESSIBLE SOCIAL ANCHORS W/ A11Y PRINCIPLES

### DIFF
--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -35,7 +35,7 @@ export default function Footer() {
                 target="_blank"
                 aria-label="Join us on Discord"
                 title="Discord (External Link)"
-                rel=”noopener noreferrer” 
+                rel="noopener noreferrer" 
                 className="dark:fill-white "
               >
                 <Icons.discord
@@ -49,7 +49,7 @@ export default function Footer() {
                   target="_blank"
                   aria-label="Visit us on Twitter"
                   title="Twitter (External Link)"
-                  rel=”noopener noreferrer”
+                  rel="noopener noreferrer"
                 >
                 <Icons.twitter
                   className="cursor-pointer transition duration-500 hover:scale-150 hover:fill-blue-800"
@@ -62,7 +62,7 @@ export default function Footer() {
                   target="_blank"
                   aria-label="Visit us on Github"
                   title="Github (External Link)"
-                  rel=”noopener noreferrer” 
+                  rel="noopener noreferrer" 
                 >
                 <Icons.gitHub
                   className="cursor-pointer transition duration-500 hover:scale-150 hover:fill-blue-800"
@@ -75,7 +75,7 @@ export default function Footer() {
                   target="_blank"
                   aria-label="Visit us on Linkedin"
                   title="Linkedin (External Link)"
-                  rel=”noopener noreferrer” 
+                  rel="noopener noreferrer" 
                 >
                 <Icons.linkedin
                   className="cursor-pointer transition  duration-500 hover:scale-150 hover:fill-blue-800"

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -33,6 +33,9 @@ export default function Footer() {
               <Link
                 href={siteConfig.links.webxdao_discord}
                 target="_blank"
+                aria-label="Join us on Discord"
+                title="Discord (External Link)"
+                rel=”noopener noreferrer” 
                 className="dark:fill-white "
               >
                 <Icons.discord
@@ -41,21 +44,39 @@ export default function Footer() {
                   height={25}
                 />
               </Link>
-              <Link href={siteConfig.links.webxdao_twitter} target="_blank">
+              <Link 
+                  href={siteConfig.links.webxdao_twitter}
+                  target="_blank"
+                  aria-label="Visit us on Twitter"
+                  title="Twitter (External Link)"
+                  rel=”noopener noreferrer”
+                >
                 <Icons.twitter
                   className="cursor-pointer transition duration-500 hover:scale-150 hover:fill-blue-800"
                   width={25}
                   height={25}
                 />
               </Link>
-              <Link href={siteConfig.links.webxdao_gh} target="_blank">
+              <Link 
+                  href={siteConfig.links.webxdao_gh} 
+                  target="_blank"
+                  aria-label="Visit us on Github"
+                  title="Github (External Link)"
+                  rel=”noopener noreferrer” 
+                >
                 <Icons.gitHub
                   className="cursor-pointer transition duration-500 hover:scale-150 hover:fill-blue-800"
                   width={25}
                   height={25}
                 />
               </Link>
-              <Link href={siteConfig.links.webxdao_linkedin} target="_blank">
+              <Link 
+                  href={siteConfig.links.webxdao_linkedin} 
+                  target="_blank"
+                  aria-label="Visit us on Linkedin"
+                  title="Linkedin (External Link)"
+                  rel=”noopener noreferrer” 
+                >
                 <Icons.linkedin
                   className="cursor-pointer transition  duration-500 hover:scale-150 hover:fill-blue-800"
                   width={25}

--- a/components/main-nav.tsx
+++ b/components/main-nav.tsx
@@ -65,6 +65,8 @@ export function MainNav({ items }: MainNavProps) {
               href={siteConfig.links.webxdao_gh}
               target="_blank"
               rel="noreferrer"
+              aria-label="Visit us on Github"
+              title="Github (External Link)"
             >
               <div
                 className={buttonVariants({
@@ -81,6 +83,8 @@ export function MainNav({ items }: MainNavProps) {
               href={siteConfig.links.webxdao_twitter}
               target="_blank"
               rel="noreferrer"
+              aria-label="Visit us on Twitter"
+              title="Twitter (External Link)"
             >
               <div
                 className={buttonVariants({
@@ -146,6 +150,8 @@ export function MainNav({ items }: MainNavProps) {
                 <Link
                   href={siteConfig.links.webxdao_gh}
                   target="_blank"
+                  aria-label="Visit us on Github"
+                  title="Github (External Link)"
                   rel="noreferrer"
                 >
                   <div
@@ -162,6 +168,8 @@ export function MainNav({ items }: MainNavProps) {
                 <Link
                   href={siteConfig.links.webxdao_twitter}
                   target="_blank"
+                  aria-label="Visit us on Twitter"
+                  title="Twitter (External Link)"
                   rel="noreferrer"
                 >
                   <div


### PR DESCRIPTION
## Related Issue
The issue is about making accessible social anchor elements which are crucial for every site, by following `A11y` principles

This PR Closes/Fixes: #398 

### Changes we made
- Added `aria-label` attribute for social anchors like github & twitter
- The `aria-label` attribute is important for screen readers because it provides a text label for an object, such as `a` with social icons. When a screen reader encounters the object, the `aria-label` text is read so that the user will know what it is. 
- This is important for people who are blind or have low vision, as they rely on screen readers to access the web.
- Added `title` attribute, because the title attribute is intended to provide additional information to screen reader users.
- And along with that i added `rel` for the anchors which are lacking them to ensure best practices for crawlers
- Because adding the `rel="noopener noreferrer"` attribute can help to protect this website from security vulnerabilities and improve performance. It is a good practice to use this attribute on all external links.
- Overall this PR is intended to make necessary changes to meet best practices for crawlers along with improving accessibility for social anchors

## Type of change

What sort of change have you made:

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?
- Tested with Talkback for Mobile devices & NVDA for Desktops

## Checklist

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [x] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)
- We can't take screenshots of accessibility changes rather than code changes, Accessibility changes are often invisible to the user because it's intended to guide disabled people

## Code of Conduct
- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
