### PR TITLE
card widths in Blurb section

### DIFF
--- a/src/components/landing/Blurbs.tsx
+++ b/src/components/landing/Blurbs.tsx
@@ -3,38 +3,43 @@ import { Icons } from "@/components/icons";
 export default function Blurbs() {
     return (
       <section className=" flex justify-center px-4 py-0 md:px-10">
-        <div className="my-12 flex flex-col md:flex-row md:gap-8">
-          <div className="flex flex-col items-center justify-center gap-3 text-center">
-            <div className="border-l-3 flex justify-center rounded-lg border-white bg-white p-8 shadow-md shadow-purple-300 transition-all duration-300 hover:-translate-y-2 hover:scale-105">
-              <Icons.collaborate className="h-15 w-15 mr-1" />
-            </div>
-            <div className="text-lg font-bold">Collaborate</div>
-            <span className="text-sm">
-              Collaborate with other members to achieve common goals and objectives.
-            </span>
-          </div>
-
-          <div className="mt-8 flex flex-col items-center justify-center gap-3 text-center md:mt-0">
-            <div className="border-l-3 flex justify-center rounded-lg border-white bg-white p-8 shadow-md shadow-purple-300 transition-all duration-300 hover:-translate-y-2 hover:scale-105">
-              <Icons.blockchain className="h-15 w-15 mr-1" />
-            </div>
-            <div className="text-lg font-bold">Blockchain</div>
-            <span className="text-sm">
-              Dedicated to exploring new ways to leverage the power of this transformative
-              technology.
-            </span>
-          </div>
-
-          <div className="mt-8 flex flex-col items-center justify-center gap-3 text-center md:mt-0">
-            <div className="border-l-3 flex justify-center rounded-lg border-white bg-white p-8 shadow-md shadow-purple-300 transition-all duration-300 hover:-translate-y-2 hover:scale-105">
-              <Icons.decentralization className="h-15 w-15 mr-1" />
-            </div>
-            <div className="text-lg font-bold">Decentralization</div>
-            <span className="text-sm">
-              Operates in a decentralized manner, giving power to its community members.
-            </span>
-          </div>
+        <div className="my-12 flex flex-col md:flex-row md:gap-10 lg:gap-20">
+          <Card
+            title="Collaborate"
+            desc="Collaborate with other members to achieve common goals and objectives."
+            icon={<Icons.collaborate className="h-15 w-15 mr-1" />}
+          />
+          <Card
+            title="Blockchain"
+            desc="Dedicated to exploring new ways to leverage the power of this transformative technology."
+            icon={<Icons.blockchain className="h-15 w-15 mr-1" />}
+          />
+          <Card
+            title="Decentralization"
+            desc="Operates in a decentralized manner, giving power to its community members."
+            icon={<Icons.decentralization className="h-15 w-15 mr-1" />}
+          />
         </div>
       </section>
     );
+}
+
+interface Cards {
+  title: string,
+  desc: string,
+  icon: JSX.Element,
+}
+
+function Card({title, desc, icon}: Cards) {
+  return (
+    <div className="mt-8 flex flex-col items-center justify-center gap-3 text-center md:mt-0">
+      <div className="border-l-3 flex justify-center rounded-lg border-white bg-white p-8 shadow-md shadow-purple-300 transition-all duration-300 hover:-translate-y-2 hover:scale-105">
+        {icon}
+      </div>
+      <div className="text-lg font-bold">{title}</div>
+      <span className="text-sm max-w-xs">
+        {desc}
+      </span>
+    </div>
+  );
 }

--- a/src/components/landing/Blurbs.tsx
+++ b/src/components/landing/Blurbs.tsx
@@ -37,7 +37,7 @@ function Card({title, desc, icon}: Cards) {
         {icon}
       </div>
       <div className="text-lg font-bold">{title}</div>
-      <span className="text-sm max-w-xs">
+      <span className="max-w-xs text-sm">
         {desc}
       </span>
     </div>


### PR DESCRIPTION
## Related Issue

- Information about the related issue

Closes: #350 <!-- issue number that will be closed through this PR -->

### Describe the changes you've made
Implemented consistent card widths in the Blurb section, ensuring a visually pleasing layout. Addressed the lack of set max-width for descriptions on both desktop and mobile, resulting in improved readability and aesthetics.

<!-- Give a clear description of what modifications you have made -->

## Type of change

What sort of change have you made:

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Code style update (formatting, local variables)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update.
- [ ] This change requires a documentation update

## How Has This Been Tested?

<!-- Describe how have you verified the changes made -->

## Checklist

<!--
Example how to mark a checkbox:-
- [x] My code follows the code style of this project.
-->

- [x] My code follows the guidelines of this project.
- [x] I have performed a self-review of my own code.
- [x] I have commented on my code, particularly wherever it was hard to understand.
- [x] I have made corresponding changes to the documentation.
- [x] My changes generate no new warnings.
- [x] I have added tests that prove my fix is effective or that my feature works.
- [ ] Any dependent changes have been merged and published in downstream modules.

## Screenshots (if applicable)

|      Original       |      Updated       |
| :-----------------: | :----------------: |
| ![image](https://github.com/WebXDAO/WebXDAO.github.io/assets/104740281/81528d15-f6fb-48d4-a8bc-9233000ec089) | ![image](https://github.com/WebXDAO/WebXDAO.github.io/assets/104740281/99e4e06b-5675-43a2-a887-b9aed4a854e0) |
| ![image](https://github.com/WebXDAO/WebXDAO.github.io/assets/104740281/2fbb45f0-4866-404f-934d-d54cc44ebbb1) | ![image](https://github.com/WebXDAO/WebXDAO.github.io/assets/104740281/8439751d-0898-4607-95d6-3a18b4b8cbcf) |


## Code of Conduct

- [x] I agree to follow this project's [Code of Conduct](https://github.com/WebXDAO/.github/blob/main/CODE_OF_CONDUCT.md)
